### PR TITLE
Make sure iconv isn't compiled to native code

### DIFF
--- a/src/iconv.erl
+++ b/src/iconv.erl
@@ -25,6 +25,8 @@
 
 -author('alexey@process-one.net').
 
+-compile(no_native).
+
 -export([load_nif/0, load_nif/1, convert/3]).
 
 -ifdef(TEST).


### PR DESCRIPTION
NIFs [cannot](http://erlang.org/pipermail/erlang-questions/2011-June/059237.html) be loaded from a HiPE-compiled module.
