### PR TITLE
Added p1_utils to prevent crash in production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can use `iconv` with Elixir `mix` by adding the dependency as follows:
   defp deps do
     [
       {:iconv, "~> 1.0.10"},
+      {:p1_utils, "~> 1.0.10"}
     ]
   end
 ```


### PR DESCRIPTION
We need to add `p1_utils` to the dependencies to prevent a crash during the start of the app.