### PR TITLE
PR_erlang-p1-iconv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - ppc64le
+  - amd64
 language: erlang
 
 os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,15 @@ otp_release:
   - 19.3
   - 22.3
   - 23.0
+# Disable otp_release 17.1, 17.5, 18.1, 19.3 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
+jobs: 
+ exclude:
+  - arch: ppc64le
+    otp_release: 17.1
+  - arch: ppc64le
+    otp_release: 17.5
+  - arch: ppc64le
+    otp_release: 18.1
+  - arch: ppc64le
+    otp_release: 19.3
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ dist: xenial
 
 before_install:
   - pip install --user cpp-coveralls coveralls-merge
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
 
 install:
   - ./configure --enable-gcov


### PR DESCRIPTION
Adding power support ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The Build is successful as per the comments present in the commit section.